### PR TITLE
Uses Timer without TimeLine for tests

### DIFF
--- a/TimeCoach Watch App/TimeCoachApp.swift
+++ b/TimeCoach Watch App/TimeCoachApp.swift
@@ -22,7 +22,7 @@ struct TimeCoach_Watch_AppApp: App {
     init(timerCoundown: TimerCountdown, timerState: TimerSave & TimerLoad) {
         let root = TimeCoachRoot(timerCoundown: timerCoundown, timerState: timerState)
         self.root = root
-        self.timerView = root.createTimer()
+        self.timerView = root.createTimer(withTimeLine: false)
     }
     
     var body: some Scene {

--- a/TimeCoach Watch App/Timer Composition/TimeCoachRoot.swift
+++ b/TimeCoach Watch App/Timer Composition/TimeCoachRoot.swift
@@ -28,13 +28,14 @@ class TimeCoachRoot {
         self.timerLoad = timerState
     }
     
-    func createTimer() -> TimerView {
+    func createTimer(withTimeLine: Bool = true) -> TimerView {
         return TimerViewComposer.createTimer(
             customFont: CustomFont.timer.font,
             playPublisher: timerCoundown.createStartTimer(),
             skipPublisher: timerCoundown.createSkipTimer(),
             stopPublisher: timerCoundown.createStopTimer(),
-            pausePublisher: timerCoundown.createPauseTimer()
+            pausePublisher: timerCoundown.createPauseTimer(),
+            withTimeLine: withTimeLine
         )
     }
     

--- a/TimeCoach Watch App/Timer Composition/TimerView.swift
+++ b/TimeCoach Watch App/Timer Composition/TimerView.swift
@@ -3,22 +3,36 @@ import LifeCoachWatchOS
 import SwiftUI
 
 public struct TimerView: View {
-    public var timer: TimerTextTimeLine
+    public var timerWithTimeLine: TimerTextTimeLine?
+    public var timerWithoutTimeLine: TimerText?
     public var controls: TimerControls
+    var withTimeLine = true
     
-    public init(timerViewModel: TimerViewModel,
-         togglePlayback: (() -> Void)? = nil,
-         skipHandler: (() -> Void)? = nil,
-         stopHandler: (() -> Void)? = nil,
-         customFont: String? = nil
+    public init(
+        timerViewModel: TimerViewModel,
+        togglePlayback: (() -> Void)? = nil,
+        skipHandler: (() -> Void)? = nil,
+        stopHandler: (() -> Void)? = nil,
+        customFont: String? = nil,
+        withTimeLine: Bool = false
     ) {
-        self.timer = TimerTextTimeLine(timerViewModel: timerViewModel, customFont: customFont)
+        if withTimeLine {
+            self.timerWithTimeLine = TimerTextTimeLine(timerViewModel: timerViewModel, customFont: customFont)
+        } else {
+            self.timerWithoutTimeLine = TimerText(timerViewModel: timerViewModel, mode: .full, customFont: customFont)
+        }
+        
+        self.withTimeLine = withTimeLine
         self.controls = TimerControls(togglePlayback: togglePlayback, skipHandler: skipHandler, stopHandler: stopHandler)
     }
     
     public var body: some View {
         VStack {
-            timer
+            if withTimeLine {
+                timerWithTimeLine
+            } else {
+                timerWithoutTimeLine
+            }
             controls
         }
     }

--- a/TimeCoach Watch App/Timer Composition/TimerViewComposer.swift
+++ b/TimeCoach Watch App/Timer Composition/TimerViewComposer.swift
@@ -8,7 +8,8 @@ public final class TimerViewComposer {
         playPublisher: AnyPublisher<ElapsedSeconds, Error>,
         skipPublisher: AnyPublisher<ElapsedSeconds, Error>,
         stopPublisher: AnyPublisher<ElapsedSeconds, Error>,
-        pausePublisher: AnyPublisher<ElapsedSeconds, Error>
+        pausePublisher: AnyPublisher<ElapsedSeconds, Error>,
+        withTimeLine: Bool = true
     ) -> TimerView {
         let viewModel = TimerViewModel()
 
@@ -30,7 +31,8 @@ public final class TimerViewComposer {
             playHandler: starTimerAdapter.start,
             pauseHandler: pauseTimerAdapter.pause,
             skipHandler: skipTimerAdapter.skip,
-            stopHandler: stopTimerAdapter.stop
+            stopHandler: stopTimerAdapter.stop,
+            withTimeLine: withTimeLine
         )
         return timer
     }

--- a/TimeCoach Watch App/Timer Composition/TimerViewComposer.swift
+++ b/TimeCoach Watch App/Timer Composition/TimerViewComposer.swift
@@ -41,7 +41,8 @@ public final class TimerViewComposer {
         playHandler: (() -> Void)? = nil,
         pauseHandler: (() -> Void)? = nil,
         skipHandler: (() -> Void)? = nil,
-        stopHandler: (() -> Void)? = nil
+        stopHandler: (() -> Void)? = nil,
+        withTimeLine: Bool = true
     ) -> TimerView {
         let toggleStrategy = ToggleStrategy(start: playHandler,
                                             pause: pauseHandler,
@@ -53,7 +54,8 @@ public final class TimerViewComposer {
             togglePlayback: toggleStrategy.toggle,
             skipHandler: toggleStrategy.skipHandler,
             stopHandler: toggleStrategy.stopHandler,
-            customFont: customFont
+            customFont: customFont,
+            withTimeLine: withTimeLine
         )
         return timer
     }

--- a/TimeCoach Watch AppTests/TimerUI/TimerUIIntegrationTests.swift
+++ b/TimeCoach Watch AppTests/TimerUI/TimerUIIntegrationTests.swift
@@ -157,7 +157,8 @@ final class TimerUIIntegrationTests: XCTestCase {
             playHandler: playHandler,
             pauseHandler: pauseHandler,
             skipHandler: skipHandler,
-            stopHandler: stopHandler
+            stopHandler: stopHandler,
+            withTimeLine: false
         )
     
         trackForMemoryLeak(instance: timeLoader)
@@ -179,6 +180,6 @@ final class TimerUIIntegrationTests: XCTestCase {
 
 extension TimerView {
     var customFont: String? {
-        timer.customFont
+        timerWithoutTimeLine?.customFont
     }
 }

--- a/TimeCoach Watch AppTests/TimerUI/TimerUIIntegrationTests.swift
+++ b/TimeCoach Watch AppTests/TimerUI/TimerUIIntegrationTests.swift
@@ -7,6 +7,15 @@ import LifeCoachWatchOS
 import TimeCoach_Watch_App
 
 extension TimerView: Inspectable { }
+extension TimelineView: Inspectable {
+    public var entity: ViewInspector.Content.InspectableEntity {
+        .view
+    }
+    
+    public func extractContent(environmentObjects: [AnyObject]) throws -> Any {
+        0
+    }
+}
 
 final class TimerUIIntegrationTests: XCTestCase {
     func test_onInitialLoad_shouldDisplayCorrectCustomFont() {


### PR DESCRIPTION
Uses Timer without TimeLine for tests.  This is because tests would fail using `TimelineView` on CI Server when running UI `TimerText` with `TimelineView` SwiftUI component.